### PR TITLE
Fix labelgetter() json path to use laytoutItems.label

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,8 +252,8 @@
 					 <artifactId>maven-javadoc-plugin</artifactId>         
 					 <version>3.0.0</version> 
 					 <configuration>
-    <additionalparam>-Xdoclint:none</additionalparam>
-  </configuration>
+    					<doclint>none</doclint>
+  					 </configuration>
 					 <executions>   
 					 <execution>    <id>attach-javadocs</id>   <goals>     <goal>jar</goal>   </goals>   </execution>  
 					 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>23.0</version>
+			<version>33.2.0-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<selinium.java.version>3.141.59</selinium.java.version>
 		<apache.httpcomponents.core.version>4.4.4</apache.httpcomponents.core.version>
-		<apache.httpcomponents.client.version>4.5.13</apache.httpcomponents.client.version>
+		<apache.httpcomponents.client.version>4.5.14</apache.httpcomponents.client.version>
 		<testng.version>7.0.0</testng.version>
 		<commons-lang.version>2.6</commons-lang.version>
 		<super-csv.version>2.4.0</super-csv.version>
@@ -45,8 +45,7 @@
 		<json.version>20160810</json.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<version.commons-io>2.4</version.commons-io>
-		
+		<version.commons-io>2.16.1</version.commons-io>
 	</properties>
 
 	<dependencies>
@@ -71,7 +70,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.2</version>
+			<version>2.10.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<testng.version>7.0.0</testng.version>
 		<commons-lang.version>2.6</commons-lang.version>
 		<super-csv.version>2.4.0</super-csv.version>
-		<jsoup.version>1.10.1</jsoup.version>
+		<jsoup.version>1.17.2</jsoup.version>
 		<rest-assured.version>2.9.0</rest-assured.version>
 		<junit.version>4.12</junit.version>
 		<opencsv.version>2.3</opencsv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.testzeus</groupId>
 	<artifactId>Test_Zeus</artifactId>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 	<packaging>jar</packaging> 
 	<name>TestZeus</name>
 	<description>UI and API testing framework built specifically for Salesforce</description>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<selinium.java.version>3.141.59</selinium.java.version>
 		<apache.httpcomponents.core.version>4.4.4</apache.httpcomponents.core.version>
-		<apache.httpcomponents.client.version>4.5.2</apache.httpcomponents.client.version>
+		<apache.httpcomponents.client.version>4.5.13</apache.httpcomponents.client.version>
 		<testng.version>7.0.0</testng.version>
 		<commons-lang.version>2.6</commons-lang.version>
 		<super-csv.version>2.4.0</super-csv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,14 @@
 <!-- 		</dependency> -->
 
 		<dependency>
+			<groupId>net.minidev</groupId>
+			<artifactId>json-smart</artifactId>
+			<version>2.5.1</version>
+		</dependency>
+		<dependency>
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
-			<version>2.4.0</version>
+			<version>2.9.0</version>
 		</dependency>
 
 	

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<rest-assured.version>2.9.0</rest-assured.version>
 		<junit.version>4.12</junit.version>
 		<opencsv.version>2.3</opencsv.version>
-		<json.version>20160810</json.version>
+		<json.version>20240303</json.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<version.commons-io>2.16.1</version.commons-io>

--- a/pom.xml
+++ b/pom.xml
@@ -192,13 +192,13 @@
 <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
-    <version>2.12.3</version>
+    <version>2.17.1</version>
 </dependency>
 
 <dependency>
     <groupId>io.github.bonigarcia</groupId>
     <artifactId>webdrivermanager</artifactId>
-    <version>5.0.3</version>
+    <version>5.8.0</version>
     <scope>test</scope>
 </dependency>
 

--- a/src/main/java/testzeus/base/SFPageBase.java
+++ b/src/main/java/testzeus/base/SFPageBase.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashSet;
 import org.openqa.selenium.By.ByName;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -107,7 +108,9 @@ public static void sectionGetter() throws Exception {
 	public static void labelGetter() throws Exception {
 		// These labels are gathered from layoutComponents as we get labels which are
 		// actually displayed on the UI rather than all the fields for the sObject
-		String labelpath = "$..[?(@.editableForUpdate == true)].layoutComponents..label";
+
+//		String labelpath = "$..[?(@.editableForUpdate == true)].layoutComponents..label";	// Fix v1.0.5
+		String labelpath = "$..[?(@.editableForUpdate == true)]..label";
 		JSONArray listofduplicatelabels = JsonPath.read(uiapi_record_json, labelpath);
 		// As we are hitting modes=View, Edit, hence we are getting duplicates.
 		LinkedHashSet<String> labels = new LinkedHashSet<String>();
@@ -161,7 +164,8 @@ public static void sectionGetter() throws Exception {
 			Thread.sleep(5000);
 			// Locator design inspired by
 			// https://trailblazers.salesforce.com/_ui/core/chatter/groups/GroupProfilePage?g=0F93A000000DQPd&fId=0D54S000008HKSK
-			we = driver.findElement(ByName.xpath("//input[@id=string(//label[text()='" + label + "']/@for)]"));
+//			we = driver.findElement(ByName.xpath("//input[@id=string(//label[text()='" + label + "']/@for)]"));
+			we = findElementByXpath("//input[@id=string(//label[text()='" + label + "']/@for)]", type);
 			we.sendKeys(targetvalue);
 			System.out.println("Sent values as " + targetvalue);
 			break;
@@ -232,4 +236,32 @@ public static void sectionGetter() throws Exception {
 
 	}
 
+	/***
+     * <pre>Locates an element, doing some creative error handling where it can help find the element</pre>
+     * @author <a href="https://github.com/shawnjburke">Shawn J Burke</a>
+     * @param xPath - valid Xpath locator string
+     * @param expectedSalesForceType - Identified field type. String, Url, Int, Phone, Currency, Double, Date, Boolean,  TextArea, Picklist, Reference.
+     * @return the found WebElement
+     */
+	public WebElement findElementByXpath(String xPath, String expectedSalesForceType) {
+		WebElement we = null;
+		try {
+			we = driver.findElement(ByName.xpath(xPath));
+		} catch(NoSuchElementException noWe) {
+			// Check type and perform only if applicable for performance
+			System.out.println("Expected sales force field type = " + expectedSalesForceType);
+			if(expectedSalesForceType.equalsIgnoreCase("[\"string\"]")) {
+				// In a customized SalesForce instance a TextArea for Description field on account object becomes
+				// identified as a string.  Let's see if we can modify the XPath expression for a TextArea.  If found
+				// use it.
+				System.out.println("Xpath not found: " + xPath);
+				String newPath = "//textarea" + xPath.substring(xPath.indexOf("//input")+7);
+				System.out.println("Attempting alternate xPath: " + newPath);
+				// If not found will throw the error to the stack
+				we = driver.findElement(ByName.xpath(newPath));
+			}
+		}
+
+		return we;
+	}
 }

--- a/src/main/java/testzeus/base/SFPageBase.java
+++ b/src/main/java/testzeus/base/SFPageBase.java
@@ -238,7 +238,6 @@ public static void sectionGetter() throws Exception {
 
 	/***
      * <pre>Locates an element, doing some creative error handling where it can help find the element</pre>
-     * @author <a href="https://github.com/shawnjburke">Shawn J Burke</a>
      * @param xPath - valid Xpath locator string
      * @param expectedSalesForceType - Identified field type. String, Url, Int, Phone, Currency, Double, Date, Boolean,  TextArea, Picklist, Reference.
      * @return the found WebElement


### PR DESCRIPTION
The labelGettter() reads the SalesForce UI API and determines labels by reading layoutItems.layoutComponents.labels.

In a customized version of SalesForce it appears that path is incorrect.  Rather it should read the parent layoutItems.labels instead.  That was updated.

Update testzeus-archetype POM to <version>1.0.5</version>.

In addition, an inconsistency in the UI API causes one field to be identified as an input instead of a TextArea.  A new method findElementByXpath was added.  It will trap the NoSuchElement when looking for a ["String"] type, and then attempt a //textarea xpath over an //input xPath.

Finally POM entries for vulnerable dependencies were updated.  EXCEPT Selenium3.  Major version jump to 4 seemed out of scope.  Also not clear if it's even necessary since the WebDriverManager is in use (io.github.bonigarcia).  Thus left it untouched for now.